### PR TITLE
Updates to Hopper 4.9.6

### DIFF
--- a/cpus/GBCPU/GBCPU/GBCPU.m
+++ b/cpus/GBCPU/GBCPU/GBCPU.m
@@ -52,7 +52,7 @@
     return @"0.0.1";
 }
 
-- (NSString *)commandLineIdentifier {
+- (NSString *)commandLineIdentifiers {
     return @"gb";
 }
 

--- a/include/Hopper/CPUContext.h
+++ b/include/Hopper/CPUContext.h
@@ -26,9 +26,9 @@
 
 @protocol CPUContext
 
-- (NSObject<CPUDefinition> *)cpuDefinition;
+- (nonnull NSObject<CPUDefinition> *)cpuDefinition;
 
-- (void)initDisasmStructure:(DisasmStruct*)disasm withSyntaxIndex:(NSUInteger)syntaxIndex;
+- (void)initDisasmStructure:(nonnull DisasmStruct*)disasm withSyntaxIndex:(NSUInteger)syntaxIndex;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -71,16 +71,16 @@
 - (void)analysisEnded;
 
 /// A Procedure object is about to be created.
-- (void)procedureAnalysisBeginsForProcedure:(NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
+- (void)procedureAnalysisBeginsForProcedure:(nonnull NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
 /// The prolog of the created procedure is being analyzed.
 /// Warning: this method is not called at the begining of the procedure creation, but once all basic blocks
 /// have been created.
-- (void)procedureAnalysisOfPrologForProcedure:(NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
-- (void)procedureAnalysisOfEpilogForProcedure:(NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
-- (void)procedureAnalysisEndedForProcedure:(NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
+- (void)procedureAnalysisOfPrologForProcedure:(nonnull NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
+- (void)procedureAnalysisOfEpilogForProcedure:(nonnull NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
+- (void)procedureAnalysisEndedForProcedure:(nonnull NSObject<HPProcedure> *)procedure atEntryPoint:(Address)entryPoint;
 
 /// A new basic bloc is created
-- (void)procedureAnalysisContinuesOnBasicBlock:(NSObject<HPBasicBlock> *)basicBlock;
+- (void)procedureAnalysisContinuesOnBasicBlock:(nonnull NSObject<HPBasicBlock> *)basicBlock;
 
 /// This method may be called when the internal state of the disassembler should be reseted.
 /// For instance, the ARM plugin maintains a state during the disassembly process to
@@ -90,40 +90,40 @@
 /// Disassemble a single instruction, filling the DisasmStruct structure.
 /// Only a few fields are set by Hopper (mainly, the syntaxIndex, the "bytes" field and the virtualAddress of the instruction).
 /// The CPU should fill as much information as possible.
-- (int)disassembleSingleInstruction:(DisasmStruct *)disasm usingProcessorMode:(NSUInteger)mode;
+- (int)disassembleSingleInstruction:(nonnull DisasmStruct *)disasm usingProcessorMode:(NSUInteger)mode;
 
 /// Returns whether or not an instruction may halt the processor (like the HLT Intel instruction).
-- (BOOL)instructionHaltsExecutionFlow:(DisasmStruct *)disasm;
+- (BOOL)instructionHaltsExecutionFlow:(nonnull DisasmStruct *)disasm;
 
 /// These methods are called to let you update your internal plugin state during the analysis.
-- (void)performProcedureAnalysis:(NSObject<HPProcedure> *)procedure basicBlock:(NSObject<HPBasicBlock> *)basicBlock disasm:(DisasmStruct *)disasm;
-- (void)updateProcedureAnalysis:(DisasmStruct *)disasm;
+- (void)performProcedureAnalysis:(nonnull NSObject<HPProcedure> *)procedure basicBlock:(nonnull NSObject<HPBasicBlock> *)basicBlock disasm:(nonnull DisasmStruct *)disasm;
+- (void)updateProcedureAnalysis:(nonnull DisasmStruct *)disasm;
 
 /// Return YES if the provided DisasmStruct represents an instruction that can directly reference a memory address.
 /// Ususally, this methods returns YES. This is used by the ARM plugin to avoid false references on "MOVW" instruction
 /// for instance.
-- (BOOL)instructionCanBeUsedToExtractDirectMemoryReferences:(DisasmStruct *)disasmStruct;
+- (BOOL)instructionCanBeUsedToExtractDirectMemoryReferences:(nonnull DisasmStruct *)disasmStruct;
 
 /// Return YES if the instruction is used to load an address, but will not read, or write at this address.
 /// Example: the "LEA" x86 instruction.
-- (BOOL)instructionOnlyLoadsAddress:(DisasmStruct *)disasmStruct;
+- (BOOL)instructionOnlyLoadsAddress:(nonnull DisasmStruct *)disasmStruct;
 
 /// Return YES if the instruction uses float.
-- (BOOL)instructionManipulatesFloat:(DisasmStruct *)disasmStruct;
+- (BOOL)instructionManipulatesFloat:(nonnull DisasmStruct *)disasmStruct;
 
 /// This method is called on branching instruction (like CALL on x86, or BL on ARM).
 /// If the instruction conditions the CPU mode of the target address, the method should return YES, and set the cpuMode given in argument.
 /// Otherwise, return NO if you don't know if the CPU mode is altered.
-- (BOOL)instructionConditionsCPUModeAtTargetAddress:(DisasmStruct *)disasmStruct resultCPUMode:(uint8_t *)cpuMode;
+- (BOOL)instructionConditionsCPUModeAtTargetAddress:(nonnull DisasmStruct *)disasmStruct resultCPUMode:(nonnull uint8_t *)cpuMode;
 
 /// This method is called during the analysis when the field disasm.instruction.specialFlags.changeNextInstrMode is set in order
 /// to determine the future CPU mode for the next instruction.
-- (uint8_t)cpuModeForNextInstruction:(DisasmStruct *)disasmStruct;
+- (uint8_t)cpuModeForNextInstruction:(nonnull DisasmStruct *)disasmStruct;
 
 /// Return YES if the instruction may be used to build a switch/case statement.
 /// For instance, for the Intel processor, it returns YES for the "JMP reg" and the "JMP [xxx+reg*4]" instructions,
 /// and for the Am processor, it returns YES for the "TBB" and "TBH" instructions.
-- (BOOL)instructionMayBeASwitchStatement:(DisasmStruct *)disasmStruct;
+- (BOOL)instructionMayBeASwitchStatement:(nonnull DisasmStruct *)disasmStruct;
 
 /// If a branch instruction is found, Hopper calls this method to compute additional destinations of the instruction.
 /// The "*next" value is already set to the address which follows the instruction if the jump does not occurs.
@@ -135,19 +135,19 @@
 /// The purpose of this method is to compute additional destinations.
 /// Most of the time, Hopper already found the destinations, so there is no need to do more.
 /// This is used by the Intel CPU plugin to compute the destinations of switch/case constructions when it found a "JMP register" instruction.
-- (void)performBranchesAnalysis:(DisasmStruct *)disasm
-           computingNextAddress:(Address *)next
-                    andBranches:(NSMutableArray<NSNumber *> *)branches
-                   forProcedure:(NSObject<HPProcedure> *)procedure
-                     basicBlock:(NSObject<HPBasicBlock> *)basicBlock
-                      ofSegment:(NSObject<HPSegment> *)segment
-                calledAddresses:(NSMutableArray<NSObject<HPCallDestination> *> *)calledAddresses
-                      callsites:(NSMutableArray<NSNumber *> *)callSitesAddresses;
+- (void)performBranchesAnalysis:(nonnull DisasmStruct *)disasm
+           computingNextAddress:(nonnull Address *)next
+                    andBranches:(nonnull NSMutableArray<NSNumber *> *)branches
+                   forProcedure:(nonnull NSObject<HPProcedure> *)procedure
+                     basicBlock:(nonnull NSObject<HPBasicBlock> *)basicBlock
+                      ofSegment:(nonnull NSObject<HPSegment> *)segment
+                calledAddresses:(nonnull NSMutableArray<NSObject<HPCallDestination> *> *)calledAddresses
+                      callsites:(nonnull NSMutableArray<NSNumber *> *)callSitesAddresses;
 
 /// If you need a specific analysis, this method will be called once the previous branch analysis is performed.
 /// For instance, this is used by the ARM CPU plugin to set the type of the destination of an LDR instruction to
 /// an int of the correct size.
-- (void)performInstructionSpecificAnalysis:(DisasmStruct *)disasm forProcedure:(NSObject<HPProcedure> *)procedure inSegment:(NSObject<HPSegment> *)segment;
+- (void)performInstructionSpecificAnalysis:(nonnull DisasmStruct *)disasm forProcedure:(nonnull NSObject<HPProcedure> *)procedure inSegment:(nonnull NSObject<HPSegment> *)segment;
 
 /// Returns the destination address if the function starting at the given address is a thunk (ie: a direct jump to another method)
 /// Returns BAD_ADDRESS is the instruction is not a thunk.
@@ -161,9 +161,9 @@
 
 /// Build the complete instruction string in the DisasmStruct structure.
 /// This is the string to be displayed in Hopper.
-- (NSObject<HPASMLine> *)buildMnemonicString:(DisasmStruct *)disasm inFile:(NSObject<HPDisassembledFile> *)file;
-- (NSObject<HPASMLine> *)buildOperandString:(DisasmStruct *)disasm forOperandIndex:(NSUInteger)operandIndex inFile:(NSObject<HPDisassembledFile> *)file raw:(BOOL)raw;
-- (NSObject<HPASMLine> *)buildCompleteOperandString:(DisasmStruct *)disasm inFile:(NSObject<HPDisassembledFile> *)file raw:(BOOL)raw;
+- (nonnull NSObject<HPASMLine> *)buildMnemonicString:(nonnull DisasmStruct *)disasm inFile:(nonnull NSObject<HPDisassembledFile> *)file;
+- (nonnull NSObject<HPASMLine> *)buildOperandString:(nonnull DisasmStruct *)disasm forOperandIndex:(NSUInteger)operandIndex inFile:(nonnull NSObject<HPDisassembledFile> *)file raw:(BOOL)raw;
+- (nonnull NSObject<HPASMLine> *)buildCompleteOperandString:(nonnull DisasmStruct *)disasm inFile:(nonnull NSObject<HPDisassembledFile> *)file raw:(BOOL)raw;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -171,20 +171,20 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)canDecompileProcedure:(NSObject<HPProcedure> *)procedure;
+- (BOOL)canDecompileProcedure:(nonnull NSObject<HPProcedure> *)procedure;
 
 /// Return the address of the first instruction of the procedure, after its prolog.
-- (Address)skipHeader:(NSObject<HPBasicBlock> *)basicBlock ofProcedure:(NSObject<HPProcedure> *)procedure;
+- (Address)skipHeader:(nonnull NSObject<HPBasicBlock> *)basicBlock ofProcedure:(nonnull NSObject<HPProcedure> *)procedure;
 
 /// Return the address of the last instruction of the procedure, before its epilog.
-- (Address)skipFooter:(NSObject<HPBasicBlock> *)basicBlock ofProcedure:(NSObject<HPProcedure> *)procedure;
+- (Address)skipFooter:(nonnull NSObject<HPBasicBlock> *)basicBlock ofProcedure:(nonnull NSObject<HPProcedure> *)procedure;
 
 /// Decompile an assembly instruction.
 /// Note: ASTNode is not publicly exposed yet. You cannot write a decompiler at the moment.
-- (ASTNode *)decompileInstructionAtAddress:(Address)a
-                                    disasm:(DisasmStruct *)d
-                                 addNode_p:(BOOL *)addNode_p
-                           usingDecompiler:(Decompiler *)decompiler;
+- (nonnull ASTNode *)decompileInstructionAtAddress:(Address)a
+                                            disasm:(nonnull DisasmStruct *)d
+                                         addNode_p:(nonnull BOOL *)addNode_p
+                                   usingDecompiler:(nonnull Decompiler *)decompiler;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -192,6 +192,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-- (NSData *)assembleRawInstruction:(NSString *)instr atAddress:(Address)addr forFile:(NSObject<HPDisassembledFile> *)file withCPUMode:(uint8_t)cpuMode usingSyntaxVariant:(NSUInteger)syntax error:(NSError **)error;
+- (nonnull NSData *)assembleRawInstruction:(nonnull NSString *)instr atAddress:(Address)addr forFile:(nonnull NSObject<HPDisassembledFile> *)file withCPUMode:(uint8_t)cpuMode usingSyntaxVariant:(NSUInteger)syntax error:(NSError * _Nullable * _Nullable)error;
 
 @end

--- a/include/Hopper/CPUDefinition.h
+++ b/include/Hopper/CPUDefinition.h
@@ -19,16 +19,16 @@
 
 /// Build a context for disassembling.
 /// This method should be fast, because it'll be called very often.
-- (Class)cpuContextClass;
-- (NSObject<CPUContext> *)buildCPUContextForFile:(NSObject<HPDisassembledFile> *)file;
+- (nonnull Class)cpuContextClass;
+- (nonnull NSObject<CPUContext> *)buildCPUContextForFile:(nonnull NSObject<HPDisassembledFile> *)file;
 
 /// Returns an array of NSString of CPU families handled by the plugin.
-- (NSArray<NSString *> *)cpuFamilies;
+- (nonnull NSArray<NSString *> *)cpuFamilies;
 /// Returns an array of NSString of CPU subfamilies handled by the plugin for a given CPU family.
-- (NSArray<NSString *> *)cpuSubFamiliesForFamily:(NSString *)family;
+- (nonnull NSArray<NSString *> *)cpuSubFamiliesForFamily:(nullable NSString *)family;
 /// Returns 32 or 64, according to the family and subFamily arguments.
-- (int)addressSpaceWidthInBitsForCPUFamily:(NSString *)family andSubFamily:(NSString *)subFamily;
-- (int)integerWidthInBitsForCPUFamily:(NSString *)family andSubFamily:(NSString *)subFamily;
+- (int)addressSpaceWidthInBitsForCPUFamily:(nullable NSString *)family andSubFamily:(nullable NSString *)subFamily;
+- (int)integerWidthInBitsForCPUFamily:(nullable NSString *)family andSubFamily:(nullable NSString *)subFamily;
 
 /// Default endianess of the CPU.
 - (CPUEndianess)endianess;
@@ -37,31 +37,31 @@
 /// The number of CPU modes. For instance, 2 for the ARM CPU family: ARM and Thumb modes.
 - (NSUInteger)cpuModeCount;
 
-- (NSArray<NSString *> *)syntaxVariantNames;
-- (NSArray<NSString *> *)cpuModeNames;
+- (nonnull NSArray<NSString *> *)syntaxVariantNames;
+- (nonnull NSArray<NSString *> *)cpuModeNames;
 
 - (NSUInteger)registerClassCount;
 - (NSUInteger)registerCountForClass:(RegClass)reg_class;
-- (NSString *)registerIndexToString:(NSUInteger)reg ofClass:(RegClass)reg_class withBitSize:(NSUInteger)size position:(DisasmPosition)position andSyntaxIndex:(NSUInteger)syntaxIndex;
-- (NSString *)cpuRegisterStateMaskToString:(uint32_t)cpuState;
-- (BOOL)registerIndexIsStackPointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file;
-- (BOOL)registerIndexIsFrameBasePointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file;
-- (BOOL)registerIndexIsProgramCounter:(NSUInteger)reg cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file;
+- (nonnull NSString *)registerIndexToString:(NSUInteger)reg ofClass:(RegClass)reg_class withBitSize:(NSUInteger)size position:(DisasmPosition)position andSyntaxIndex:(NSUInteger)syntaxIndex;
+- (nonnull NSString *)cpuRegisterStateMaskToString:(uint32_t)cpuState;
+- (BOOL)registerIndexIsStackPointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(nonnull NSObject<HPDisassembledFile> *)file;
+- (BOOL)registerIndexIsFrameBasePointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(nonnull NSObject<HPDisassembledFile> *)file;
+- (BOOL)registerIndexIsProgramCounter:(NSUInteger)reg cpuMode:(uint8_t)cpuMode file:(nonnull NSObject<HPDisassembledFile> *)file;
 /// Returns true for each special registers, like "CRx" or "DRx" X86 registers for instance
 - (BOOL)registerHasSideEffectForIndex:(NSUInteger)reg andClass:(RegClass)reg_class;
 
 // Returns the name of the frame pointer register, ie, "bp" for x86, or "r7" for ARM.
-- (NSString *)framePointerRegisterNameForFile:(NSObject<HPDisassembledFile>*)file cpuMode:(uint8_t)cpuMode;
+- (nullable NSString *)framePointerRegisterNameForFile:(nonnull NSObject<HPDisassembledFile>*)file cpuMode:(uint8_t)cpuMode;
 
 /// Returns a array of bytes that represents a NOP instruction of a given size.
-- (NSData *)nopWithSize:(NSUInteger)size andMode:(NSUInteger)cpuMode forFile:(NSObject<HPDisassembledFile> *)file;
+- (nonnull NSData *)nopWithSize:(NSUInteger)size andMode:(NSUInteger)cpuMode forFile:(nonnull NSObject<HPDisassembledFile> *)file;
 
 /// Return YES if the plugin embed an assembler.
-- (BOOL)canAssembleInstructionsForCPUFamily:(NSString *)family andSubFamily:(NSString *)subFamily;
+- (BOOL)canAssembleInstructionsForCPUFamily:(nullable NSString *)family andSubFamily:(nullable NSString *)subFamily;
 
 /// Return YES if the plugin embed a decompiler.
 /// Note: you cannot create a decompiler yet, because the main class (ASTNode) is not
 /// publicly exposed yet.
-- (BOOL)canDecompileProceduresForCPUFamily:(NSString *)family andSubFamily:(NSString *)subFamily;
+- (BOOL)canDecompileProceduresForCPUFamily:(nullable NSString *)family andSubFamily:(nullable NSString *)subFamily;
 
 @end

--- a/include/Hopper/HPBasicBlock.h
+++ b/include/Hopper/HPBasicBlock.h
@@ -20,18 +20,18 @@
 - (Address)from;
 - (Address)to;
 
-- (NSObject<HPProcedure> *)procedure;
+- (nonnull NSObject<HPProcedure> *)procedure;
 - (NSUInteger)index;
 
 - (BOOL)hasSuccessors;
 - (BOOL)hasPredecessors;
 
-- (NSArray<NSObject<HPBasicBlock> *> *)predecessors;
-- (NSArray<NSObject<HPBasicBlock> *> *)successors;
+- (nullable NSArray<NSObject<HPBasicBlock> *> *)predecessors;
+- (nullable NSArray<NSObject<HPBasicBlock> *> *)successors;
 
 // Tags
-- (void)addTag:(NSObject<HPTag> *)tag;
-- (void)removeTag:(NSObject<HPTag> *)tag;
-- (BOOL)hasTag:(NSObject<HPTag> *)tag;
+- (void)addTag:(nonnull NSObject<HPTag> *)tag;
+- (void)removeTag:(nonnull NSObject<HPTag> *)tag;
+- (BOOL)hasTag:(nonnull NSObject<HPTag> *)tag;
 
 @end

--- a/include/Hopper/HPDetectedFileType.h
+++ b/include/Hopper/HPDetectedFileType.h
@@ -15,22 +15,22 @@
 @protocol HPDetectedFileType
 
 /// Internal information for the loader. You can put any value you need here.
-@property (assign) NSUInteger internalId;
-@property (strong) id internalObject;
+@property (assign)           NSUInteger internalId;
+@property (nullable, strong) id internalObject;
 
-@property (strong) NSString *shortDescriptionString;    /// This string can be used by the command line tool to select the loader.
+@property (nullable, strong) NSString *shortDescriptionString;    /// This string can be used by the command line tool to select the loader.
 
-@property (assign) BOOL compositeFile;                  /// The loader handles only a container (like a static library, a ZIP file...) and will delegate the loading process of the contained file to another loader.
+@property (assign)           BOOL compositeFile;                  /// The loader handles only a container (like a static library, a ZIP file...) and will delegate the loading process of the contained file to another loader.
 
-@property (copy)   NSString *fileDescription;
+@property (nullable, copy)   NSString *fileDescription;
 
-@property (assign) BOOL debugData;                      /// set to YES if this is debug data, like a dSYM file for instance.
-@property (assign) DFTAddressWidth addressWidth;
-@property (copy)   NSString *cpuFamily;                 /// Generic CPU family name to discriminate CPU modules. Names may be "intel", "arm", "aarch64" or any other kind.
-@property (copy)   NSString *cpuSubFamily;              /// Modes could be "x86" or "x86_64" for the "intel" family, or "v6", "v7", "v7s", "v7m" for the "arm" family.
+@property (assign)           BOOL debugData;                      /// set to YES if this is debug data, like a dSYM file for instance.
+@property (assign)           DFTAddressWidth addressWidth;
+@property (nullable, copy)   NSString *cpuFamily;                 /// Generic CPU family name to discriminate CPU modules. Names may be "intel", "arm", "aarch64" or any other kind.
+@property (nullable, copy)   NSString *cpuSubFamily;              /// Modes could be "x86" or "x86_64" for the "intel" family, or "v6", "v7", "v7s", "v7m" for the "nullable, arm" family.
 
-@property (strong) NSArray *additionalParameters;       /// An array of NSObject<HPLoaderOptionComponents> that describes some additional parameters to present to the user when using this loader.
+@property (nullable, strong) NSArray *additionalParameters;       /// An array of NSObject<HPLoaderOptionComponents> that describes some additional parameters to present to the user when using this loader.
 
-@property (assign) BOOL lowPriority;
+@property (assign)           BOOL lowPriority;
 
 @end

--- a/include/Hopper/HPDisassembledFile.h
+++ b/include/Hopper/HPDisassembledFile.h
@@ -23,18 +23,18 @@
 @protocol HPASMLine;
 @protocol HPTypeDesc;
 
-typedef void (^FileLoadingCallbackInfo)(NSString *desc, float progress);
+typedef void (^FileLoadingCallbackInfo)(NSString * _Nonnull desc, float progress);
 
 @protocol HPDisassembledFile
 
-@property (copy) HopperUUID *fileUUID;
+@property (nullable, copy) HopperUUID *fileUUID;
 
-@property (copy) NSString *cpuFamily;
-@property (copy) NSString *cpuSubFamily;
-@property (strong) NSObject<CPUDefinition> *cpuDefinition;
+@property (nullable, copy) NSString *cpuFamily;
+@property (nullable, copy) NSString *cpuSubFamily;
+@property (nonnull, strong) NSObject<CPUDefinition> *cpuDefinition;
 @property (readonly) NSUInteger userRequestedSyntaxIndex;
 
-- (NSString *)originalFilePath;
+- (nullable NSString *)originalFilePath;
 
 // Methods essentially used by Loader plugin
 - (NSUInteger)addressSpaceWidthInBits;
@@ -48,51 +48,54 @@ typedef void (^FileLoadingCallbackInfo)(NSString *desc, float progress);
 - (Address)fileBaseAddress;
 
 - (void)addEntryPoint:(Address)address;
+- (void)addEntryPoint:(Address)address withCPUMode:(uint8_t)cpuMode;
 - (void)addPotentialProcedure:(Address)address;
+- (void)addPotentialProcedure:(Address)address withCPUMode:(uint8_t)cpuMode;
 - (Address)firstEntryPoint;
-- (NSArray<NSNumber *> *)entryPointAddresses;
+- (nonnull NSArray<NSNumber *> *)entryPointAddresses;
 
 // Get access to segments and sections
-- (NSArray<NSObject<HPSegment> *> *)segments;
+- (nonnull NSArray<NSObject<HPSegment> *> *)segments;
 - (NSUInteger)segmentCount;
 
-- (NSObject<HPSegment> *)segmentForVirtualAddress:(Address)virtualAddress;
-- (NSObject<HPSection> *)sectionForVirtualAddress:(Address)virtualAddress;
+- (nullable NSObject<HPSegment> *)segmentForVirtualAddress:(Address)virtualAddress;
+- (nullable NSObject<HPSection> *)sectionForVirtualAddress:(Address)virtualAddress;
 
-- (NSObject<HPSegment> *)segmentNamed:(NSString *)name;
-- (NSObject<HPSection> *)sectionNamed:(NSString *)name;
+- (nullable NSObject<HPSegment> *)segmentNamed:(nonnull NSString *)name;
+- (nullable NSObject<HPSection> *)sectionNamed:(nonnull NSString *)name;
 
-- (NSObject<HPSegment> *)addSegmentAt:(Address)address size:(size_t)length;
-- (NSObject<HPSegment> *)addSegmentAt:(Address)address toExcludedAddress:(Address)endAddress;
+- (nonnull NSObject<HPSegment> *)addSegmentAt:(Address)address size:(size_t)length;
+- (nonnull NSObject<HPSegment> *)addSegmentAt:(Address)address toExcludedAddress:(Address)endAddress;
+- (void)removeSegment:(nonnull NSObject<HPSegment> *)segment;
 
-- (NSObject<HPSegment> *)firstSegment;
-- (NSObject<HPSegment> *)lastSegment;
-- (NSObject<HPSection> *)firstSection;
-- (NSObject<HPSection> *)lastSection;
+- (nullable NSObject<HPSegment> *)firstSegment;
+- (nullable NSObject<HPSegment> *)lastSegment;
+- (nullable NSObject<HPSection> *)firstSection;
+- (nullable NSObject<HPSection> *)lastSection;
 
-- (NSObject<HPSegment> *)previousSegment:(NSObject<HPSegment> *)segment;
-- (NSObject<HPSegment> *)nextSegment:(NSObject<HPSegment> *)segment;
+- (nullable NSObject<HPSegment> *)previousSegment:(nonnull NSObject<HPSegment> *)segment;
+- (nullable NSObject<HPSegment> *)nextSegment:(nonnull NSObject<HPSegment> *)segment;
 
 // CPUContext factory
-- (NSObject<CPUContext> *)buildCPUContext;
+- (nonnull NSObject<CPUContext> *)buildCPUContext;
 
 // Access to the labels
 /// An array of NSString objects, containing all labels.
-- (NSArray<NSString *> *)allNames;
+- (nonnull NSArray<NSString *> *)allNames;
 /// An array of NSNumber objects, representing the address of memory locations that was named.
-- (NSArray<NSNumber *> *)allNamedAddresses;
-- (NSString *)nameForVirtualAddress:(Address)virtualAddress;
-- (NSString *)nearestNameBeforeVirtualAddress:(Address)virtualAddress;
-- (void)setName:(NSString *)name forVirtualAddress:(Address)virtualAddress reason:(NameCreationReason)reason;
-- (Address)findVirtualAddressNamed:(NSString *)name;
+- (nonnull NSArray<NSNumber *> *)allNamedAddresses;
+- (nullable NSString *)nameForVirtualAddress:(Address)virtualAddress;
+- (nullable NSString *)nearestNameBeforeVirtualAddress:(Address)virtualAddress;
+- (void)setName:(nullable NSString *)name forVirtualAddress:(Address)virtualAddress reason:(NameCreationReason)reason;
+- (Address)findVirtualAddressNamed:(nonnull NSString *)name;
 
 // Comments
 - (void)removeCommentAtVirtualAddress:(Address)virtualAddress;
 - (void)removeInlineCommentAtVirtualAddress:(Address)virtualAddress;
-- (NSString *)commentAtVirtualAddress:(Address)virtualAddress;
-- (NSString *)inlineCommentAtVirtualAddress:(Address)virtualAddress;
-- (void)setComment:(NSString *)comment atVirtualAddress:(Address)virtualAddress reason:(CommentCreationReason)reason;
-- (void)setInlineComment:(NSString *)comment atVirtualAddress:(Address)virtualAddress reason:(CommentCreationReason)reason;
+- (nullable NSString *)commentAtVirtualAddress:(Address)virtualAddress;
+- (nullable NSString *)inlineCommentAtVirtualAddress:(Address)virtualAddress;
+- (void)setComment:(nullable NSString *)comment atVirtualAddress:(Address)virtualAddress reason:(CommentCreationReason)reason;
+- (void)setInlineComment:(nullable NSString *)comment atVirtualAddress:(Address)virtualAddress reason:(CommentCreationReason)reason;
 
 // Types
 - (BOOL)typeCanBeModifiedAtAddress:(Address)va;
@@ -111,14 +114,15 @@ typedef void (^FileLoadingCallbackInfo)(NSString *desc, float progress);
 - (void)setFormat:(ArgFormat)format relativeTo:(Address)relTo forArgument:(NSUInteger)argIndex atVirtualAddress:(Address)virtualAddress;
 
 // Format a number
-- (NSObject<HPASMLine> *)formatNumber:(uint64_t)immediate at:(Address)address usingFormat:(ArgFormat)format andBitSize:(uint64_t)bitSize;
+- (nonnull NSObject<HPASMLine> *)formatNumber:(uint64_t)immediate at:(Address)address operandIndex:(NSUInteger)operandIndex andBitSize:(uint64_t)bitSize;
+- (nonnull NSObject<HPASMLine> *)formatNumber:(uint64_t)immediate at:(Address)address usingFormat:(ArgFormat)format andBitSize:(uint64_t)bitSize;
 
 // Procedures
 - (BOOL)hasProcedureAt:(Address)address;
-- (NSObject<HPProcedure> *)procedureAt:(Address)address;
-- (void)removeProcedure:(NSObject<HPProcedure> *)procedure;
+- (nullable NSObject<HPProcedure> *)procedureAt:(Address)address;
+- (void)removeProcedure:(nonnull NSObject<HPProcedure> *)procedure;
 - (void)removeProcedureAt:(Address)address;
-- (NSObject<HPProcedure> *)makeProcedureAt:(Address)address;
+- (nullable NSObject<HPProcedure> *)makeProcedureAt:(Address)address;
 - (void)makeProceduresRecursivelyStartingAt:(Address)address;
 
 // Colors
@@ -130,22 +134,22 @@ typedef void (^FileLoadingCallbackInfo)(NSString *desc, float progress);
 - (void)clearColorAtRange:(AddressRange)range;
 
 // Tags
-- (NSObject<HPTag> *)tagWithName:(NSString *)tagName;
-- (NSObject<HPTag> *)buildTag:(NSString *)tagName;
-- (void)deleteTag:(NSObject<HPTag> *)tag;
-- (void)deleteTagName:(NSString *)tagName;
+- (nullable NSObject<HPTag> *)tagWithName:(nonnull NSString *)tagName;
+- (nonnull NSObject<HPTag> *)buildTag:(nonnull NSString *)tagName;
+- (void)deleteTag:(nonnull NSObject<HPTag> *)tag;
+- (void)deleteTagName:(nonnull NSString *)tagName;
 
-- (void)addTag:(NSObject<HPTag> *)tag at:(Address)address;
-- (void)removeTag:(NSObject<HPTag> *)tag at:(Address)address;
-- (NSArray<NSObject<HPTag> *> *)tagsAt:(Address)virtualAddress;
-- (BOOL)hasTag:(NSObject<HPTag> *)tag at:(Address)virtualAddress;
+- (void)addTag:(nonnull NSObject<HPTag> *)tag at:(Address)address;
+- (void)removeTag:(nonnull NSObject<HPTag> *)tag at:(Address)address;
+- (nullable NSArray<NSObject<HPTag> *> *)tagsAt:(Address)virtualAddress;
+- (BOOL)hasTag:(nonnull NSObject<HPTag> *)tag at:(Address)virtualAddress;
 
 // Problem list
-- (void)addProblemAt:(Address)address withString:(NSString *)message;
+- (void)addProblemAt:(Address)address withString:(nonnull NSString *)message;
 
 // Assembler
-- (NSData *)assembleInstruction:(NSString *)instr atAddress:(Address)address withCPUMode:(uint8_t)cpuMode usingSyntaxVariant:(NSUInteger)syntax isRawData:(BOOL *)isRawData error:(NSError **)error;
-- (NSData *)nopDataForRegion:(AddressRange)range;
+- (nullable NSData *)assembleInstruction:(nonnull NSString *)instr atAddress:(Address)address withCPUMode:(uint8_t)cpuMode usingSyntaxVariant:(NSUInteger)syntax isRawData:(nonnull BOOL *)isRawData error:(NSError * _Nonnull * _Nonnull)error;
+- (nullable NSData *)nopDataForRegion:(AddressRange)range;
 
 // Reading file
 // Warning: don't use these methods in a Loader plugin, because no CPU plugin
@@ -162,86 +166,86 @@ typedef void (^FileLoadingCallbackInfo)(NSString *desc, float progress);
 
 - (Address)readAddressAtVirtualAddress:(Address)virtualAddress;
 
-- (int64_t)readSignedLEB128AtVirtualAddress:(Address)virtualAddress length:(size_t *)numberLength;
-- (uint64_t)readUnsignedLEB128AtVirtualAddress:(Address)virtualAddress length:(size_t *)numberLength;
+- (int64_t)readSignedLEB128AtVirtualAddress:(Address)virtualAddress length:(nonnull size_t *)numberLength;
+- (uint64_t)readUnsignedLEB128AtVirtualAddress:(Address)virtualAddress length:(nonnull size_t *)numberLength;
 
-- (NSString *)readCStringAt:(Address)address;
+- (nullable NSString *)readCStringAt:(Address)address;
 
 // Misc
 - (BOOL)hasMappedDataAt:(Address)address;
-- (Address)parseAddressString:(NSString *)addressString;
+- (Address)parseAddressString:(nonnull NSString *)addressString;
 
 // Undo/Redo Stack Management
 - (BOOL)undoRedoLoggingEnabled;
 
-- (void)beginUndoRedoTransactionWithName:(NSString *)name;
+- (void)beginUndoRedoTransactionWithName:(nonnull NSString *)name;
 - (void)endUndoRedoTransaction;
 - (void)discardUndoRedoTransaction;
 
 // Types
-- (NSObject<HPTypeDesc> *)voidType;
-- (NSObject<HPTypeDesc> *)int8Type;
-- (NSObject<HPTypeDesc> *)uint8Type;
-- (NSObject<HPTypeDesc> *)int16Type;
-- (NSObject<HPTypeDesc> *)uint16Type;
-- (NSObject<HPTypeDesc> *)int32Type;
-- (NSObject<HPTypeDesc> *)uint32Type;
-- (NSObject<HPTypeDesc> *)int64Type;
-- (NSObject<HPTypeDesc> *)uint64Type;
-- (NSObject<HPTypeDesc> *)floatType;
-- (NSObject<HPTypeDesc> *)doubleType;
-- (NSObject<HPTypeDesc> *)intType;
-- (NSObject<HPTypeDesc> *)uintType;
-- (NSObject<HPTypeDesc> *)longType;
-- (NSObject<HPTypeDesc> *)ulongType;
-- (NSObject<HPTypeDesc> *)longlongType;
-- (NSObject<HPTypeDesc> *)ulonglongType;
-- (NSObject<HPTypeDesc> *)charType;
-- (NSObject<HPTypeDesc> *)ucharType;
-- (NSObject<HPTypeDesc> *)shortType;
-- (NSObject<HPTypeDesc> *)ushortType;
-- (NSObject<HPTypeDesc> *)boolType;
+- (nonnull NSObject<HPTypeDesc> *)voidType;
+- (nonnull NSObject<HPTypeDesc> *)int8Type;
+- (nonnull NSObject<HPTypeDesc> *)uint8Type;
+- (nonnull NSObject<HPTypeDesc> *)int16Type;
+- (nonnull NSObject<HPTypeDesc> *)uint16Type;
+- (nonnull NSObject<HPTypeDesc> *)int32Type;
+- (nonnull NSObject<HPTypeDesc> *)uint32Type;
+- (nonnull NSObject<HPTypeDesc> *)int64Type;
+- (nonnull NSObject<HPTypeDesc> *)uint64Type;
+- (nonnull NSObject<HPTypeDesc> *)floatType;
+- (nonnull NSObject<HPTypeDesc> *)doubleType;
+- (nonnull NSObject<HPTypeDesc> *)intType;
+- (nonnull NSObject<HPTypeDesc> *)uintType;
+- (nonnull NSObject<HPTypeDesc> *)longType;
+- (nonnull NSObject<HPTypeDesc> *)ulongType;
+- (nonnull NSObject<HPTypeDesc> *)longlongType;
+- (nonnull NSObject<HPTypeDesc> *)ulonglongType;
+- (nonnull NSObject<HPTypeDesc> *)charType;
+- (nonnull NSObject<HPTypeDesc> *)ucharType;
+- (nonnull NSObject<HPTypeDesc> *)shortType;
+- (nonnull NSObject<HPTypeDesc> *)ushortType;
+- (nonnull NSObject<HPTypeDesc> *)boolType;
 
-- (NSObject<HPTypeDesc> *)voidPtrType;
-- (NSObject<HPTypeDesc> *)int8PtrType;
-- (NSObject<HPTypeDesc> *)uint8PtrType;
-- (NSObject<HPTypeDesc> *)int16PtrType;
-- (NSObject<HPTypeDesc> *)uint16PtrType;
-- (NSObject<HPTypeDesc> *)int32PtrType;
-- (NSObject<HPTypeDesc> *)uint32PtrType;
-- (NSObject<HPTypeDesc> *)int64PtrType;
-- (NSObject<HPTypeDesc> *)uint64PtrType;
-- (NSObject<HPTypeDesc> *)floatPtrType;
-- (NSObject<HPTypeDesc> *)doublePtrType;
-- (NSObject<HPTypeDesc> *)intPtrType;
-- (NSObject<HPTypeDesc> *)uintPtrType;
-- (NSObject<HPTypeDesc> *)longPtrType;
-- (NSObject<HPTypeDesc> *)ulongPtrType;
-- (NSObject<HPTypeDesc> *)longlongPtrType;
-- (NSObject<HPTypeDesc> *)ulonglongPtrType;
-- (NSObject<HPTypeDesc> *)charPtrType;
-- (NSObject<HPTypeDesc> *)ucharPtrType;
-- (NSObject<HPTypeDesc> *)shortPtrType;
-- (NSObject<HPTypeDesc> *)ushortPtrType;
-- (NSObject<HPTypeDesc> *)boolPtrType;
+- (nonnull NSObject<HPTypeDesc> *)voidPtrType;
+- (nonnull NSObject<HPTypeDesc> *)int8PtrType;
+- (nonnull NSObject<HPTypeDesc> *)uint8PtrType;
+- (nonnull NSObject<HPTypeDesc> *)int16PtrType;
+- (nonnull NSObject<HPTypeDesc> *)uint16PtrType;
+- (nonnull NSObject<HPTypeDesc> *)int32PtrType;
+- (nonnull NSObject<HPTypeDesc> *)uint32PtrType;
+- (nonnull NSObject<HPTypeDesc> *)int64PtrType;
+- (nonnull NSObject<HPTypeDesc> *)uint64PtrType;
+- (nonnull NSObject<HPTypeDesc> *)floatPtrType;
+- (nonnull NSObject<HPTypeDesc> *)doublePtrType;
+- (nonnull NSObject<HPTypeDesc> *)intPtrType;
+- (nonnull NSObject<HPTypeDesc> *)uintPtrType;
+- (nonnull NSObject<HPTypeDesc> *)longPtrType;
+- (nonnull NSObject<HPTypeDesc> *)ulongPtrType;
+- (nonnull NSObject<HPTypeDesc> *)longlongPtrType;
+- (nonnull NSObject<HPTypeDesc> *)ulonglongPtrType;
+- (nonnull NSObject<HPTypeDesc> *)charPtrType;
+- (nonnull NSObject<HPTypeDesc> *)ucharPtrType;
+- (nonnull NSObject<HPTypeDesc> *)shortPtrType;
+- (nonnull NSObject<HPTypeDesc> *)ushortPtrType;
+- (nonnull NSObject<HPTypeDesc> *)boolPtrType;
 
-- (NSObject<HPTypeDesc> *)structureType; /// Build a new empty struct
-- (NSObject<HPTypeDesc> *)unionType;     /// Build a new empty union
-- (NSObject<HPTypeDesc> *)enumType;      /// Build a new empty enum
+- (nonnull NSObject<HPTypeDesc> *)structureType; /// Build a new empty struct
+- (nonnull NSObject<HPTypeDesc> *)unionType;     /// Build a new empty union
+- (nonnull NSObject<HPTypeDesc> *)enumType;      /// Build a new empty enum
 
-- (NSObject<HPTypeDesc> *)pointerTypeOn:(NSObject<HPTypeDesc> *)base;   /// Find the type, or build a new one.
-- (NSObject<HPTypeDesc> *)arrayTypeOf:(NSObject<HPTypeDesc> *)base withCount:(NSUInteger)count;
+- (nonnull NSObject<HPTypeDesc> *)pointerTypeOn:(nonnull NSObject<HPTypeDesc> *)base;   /// Find the type, or build a new one.
+- (nonnull NSObject<HPTypeDesc> *)arrayTypeOf:(nonnull NSObject<HPTypeDesc> *)base withCount:(NSUInteger)count;
 
 - (BOOL)hasStructureDefinedAt:(Address)address;
-- (void)defineStructure:(NSObject<HPTypeDesc> *)type at:(Address)address;
-- (NSObject<HPTypeDesc> *)structureTypeAt:(Address)address;
+- (void)defineStructure:(nonnull NSObject<HPTypeDesc> *)type at:(Address)address;
+- (nonnull NSObject<HPTypeDesc> *)structureTypeAt:(Address)address;
 
-- (NSArray<NSObject<HPTypeDesc> *> *)typeDatabase;
-- (NSObject<HPTypeDesc> *)typeWithName:(NSString *)name;
-- (NSArray<NSObject<HPTypeDesc> *> *)allStructuredTypes;
-- (NSArray<NSObject<HPTypeDesc> *> *)allEnumTypes;
+- (nonnull NSArray<NSObject<HPTypeDesc> *> *)typeDatabase;
+- (nullable NSObject<HPTypeDesc> *)typeWithName:(nonnull NSString *)name;
+- (nonnull NSArray<NSObject<HPTypeDesc> *> *)allStructuredTypes;
+- (nonnull NSArray<NSObject<HPTypeDesc> *> *)allEnumTypes;
 
-- (BOOL)importTypesFromData:(NSData *)data;
-- (NSData *)exportTypes;
+- (BOOL)importTypesFromData:(nonnull NSData *)data;
+- (nonnull NSData *)exportTypes;
 
 @end

--- a/include/Hopper/HPDocument.h
+++ b/include/Hopper/HPDocument.h
@@ -23,9 +23,9 @@ typedef void (^CancelBlock)(void);
 
 @protocol HPDocument <NSObject>
 
-- (NSObject<HPDisassembledFile> *)disassembledFile;
-- (NSObject<HPSegment> *)currentSegment;
-- (NSObject<HPSection> *)currentSection;
+- (nullable NSObject<HPDisassembledFile> *)disassembledFile;
+- (nullable NSObject<HPSegment> *)currentSegment;
+- (nullable NSObject<HPSection> *)currentSection;
 
 // Cursor position, and moving without the navigation stack
 - (Address)currentAddress;
@@ -35,7 +35,7 @@ typedef void (^CancelBlock)(void);
 
 // Moving using navigation stack
 - (void)gotoVirtualAddress:(Address)virtualAddress;
-- (BOOL)gotoVirtualAddressString:(NSString *)virtualAddressString;
+- (BOOL)gotoVirtualAddressString:(nonnull NSString *)virtualAddressString;
 - (void)popAddressFromNavigationStack;
 
 // Background process
@@ -45,19 +45,19 @@ typedef void (^CancelBlock)(void);
 
 // Determines if the user can interact with the document
 - (BOOL)isWaiting;
-- (void)beginToWait:(NSString *)message;
-- (void)beginToWait:(NSString *)message cancelBlock:(CancelBlock)block;
+- (void)beginToWait:(nullable NSString *)message;
+- (void)beginToWait:(nullable NSString *)message cancelBlock:(nullable CancelBlock)block;
 - (void)endWaiting;
 
 // Display message
-- (void)logStringMessage:(NSString *)message;
-- (void)logErrorStringMessage:(NSString *)message;
-- (void)logInfoMessage:(NSString *)message;
-- (NSInteger)displayAlertWithMessageText:(NSString *)text
-                           defaultButton:(NSString *)defaultButton
-                         alternateButton:(NSString *)alternateButton
-                             otherButton:(NSString *)otherButton
-                         informativeText:(NSString *)message;
+- (void)logStringMessage:(nonnull NSString *)message;
+- (void)logErrorStringMessage:(nonnull NSString *)message;
+- (void)logInfoMessage:(nonnull NSString *)message;
+- (NSInteger)displayAlertWithMessageText:(nonnull NSString *)text
+                           defaultButton:(nonnull NSString *)defaultButton
+                         alternateButton:(nullable NSString *)alternateButton
+                             otherButton:(nullable NSString *)otherButton
+                         informativeText:(nullable NSString *)message;
 
 // Reading and modifying file
 // These operations are performed in the endianess of the CPU module attached
@@ -73,7 +73,7 @@ typedef void (^CancelBlock)(void);
 - (uint64_t)readUInt64AtVirtualAddress:(Address)virtualAddress;
 - (Address)readAddressAtVirtualAddress:(Address)virtualAddress;
 
-- (NSString *)readCStringAt:(Address)virtualAddress;
+- (nullable NSString *)readCStringAt:(Address)virtualAddress;
 
 - (BOOL)writeInt8:(int8_t)value atVirtualAddress:(Address)virtualAddress;
 - (BOOL)writeInt16:(int16_t)value atVirtualAddress:(Address)virtualAddress;
@@ -87,6 +87,6 @@ typedef void (^CancelBlock)(void);
 
 // Global UI
 - (void)updateUI;
-- (NSWindow *)windowForSheet;
+- (nonnull NSWindow *)windowForSheet;
 
 @end

--- a/include/Hopper/HPHopperServices.h
+++ b/include/Hopper/HPHopperServices.h
@@ -12,8 +12,7 @@
 
 #import "CommonTypes.h"
 
-@class HopperUUID;
-
+@protocol HPHopperUUID;
 @protocol HPASMLine;
 @protocol HPDocument;
 @protocol HPDetectedFileType;
@@ -26,43 +25,43 @@
 - (NSInteger)hopperMajorVersion;
 - (NSInteger)hopperMinorVersion;
 - (NSInteger)hopperRevision;
-- (NSString *)hopperVersionString;
+- (nonnull NSString *)hopperVersionString;
 
-- (NSObject<HPDocument> *)currentDocument;
-- (void)logMessage:(NSString *)message;
+- (nullable NSObject<HPDocument> *)currentDocument;
+- (void)logMessage:(nonnull NSString *)message;
 
 // Build an UUID object from a string like XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-- (HopperUUID *)UUIDWithString:(NSString *)uuidString;
+- (nonnull NSObject<HPHopperUUID> *)UUIDWithString:(nonnull NSString *)uuidString;
 
 // New detected type
-- (NSObject<HPDetectedFileType> *)detectedType;
+- (nullable NSObject<HPDetectedFileType> *)detectedType;
 
 // ASMLine Constructors
-- (NSObject<HPASMLine> *)blankASMLine;
+- (nonnull NSObject<HPASMLine> *)blankASMLine;
 
-- (NSObject<HPASMLine> *)lineForFileHeader:(NSString *)fileHeader;
-- (NSObject<HPASMLine> *)lineForSegmentHeader:(NSString *)segmentHeader;
-- (NSObject<HPASMLine> *)lineForSectionHeader:(NSString *)sectionHeader;
-- (NSObject<HPASMLine> *)lineForProcedureInfo:(NSString *)procedureInfo;
-- (NSObject<HPASMLine> *)lineForSuffix:(NSString *)suffix;
-- (NSObject<HPASMLine> *)lineWithRawString:(NSString *)string;
-- (NSObject<HPASMLine> *)lineWithString:(NSString *)string;
-- (NSObject<HPASMLine> *)lineWithName:(NSString *)name atAddress:(Address)address;
-- (NSObject<HPASMLine> *)lineWithLocalName:(NSString *)name atAddress:(Address)address;
-- (NSObject<HPASMLine> *)lineWithFormattedNumber:(NSString *)string withValue:(NSNumber *)number;
-- (NSObject<HPASMLine> *)lineWithFormattedAddress:(NSString *)string withValue:(Address)address;
+- (nonnull NSObject<HPASMLine> *)lineForFileHeader:(nonnull NSString *)fileHeader;
+- (nonnull NSObject<HPASMLine> *)lineForSegmentHeader:(nonnull NSString *)segmentHeader;
+- (nonnull NSObject<HPASMLine> *)lineForSectionHeader:(nonnull NSString *)sectionHeader;
+- (nonnull NSObject<HPASMLine> *)lineForProcedureInfo:(nonnull NSString *)procedureInfo;
+- (nonnull NSObject<HPASMLine> *)lineForSuffix:(nonnull NSString *)suffix;
+- (nonnull NSObject<HPASMLine> *)lineWithRawString:(nonnull NSString *)string;
+- (nonnull NSObject<HPASMLine> *)lineWithString:(nonnull NSString *)string;
+- (nonnull NSObject<HPASMLine> *)lineWithName:(nonnull NSString *)name atAddress:(Address)address;
+- (nonnull NSObject<HPASMLine> *)lineWithLocalName:(nonnull NSString *)name atAddress:(Address)address;
+- (nonnull NSObject<HPASMLine> *)lineWithFormattedNumber:(nonnull NSString *)string withValue:(nonnull NSNumber *)number;
+- (nonnull NSObject<HPASMLine> *)lineWithFormattedAddress:(nonnull NSString *)string withValue:(Address)address;
 
 // Options for loaders
-- (NSObject<HPLoaderOptionComponents> *)addressComponentWithLabel:(NSString *)label;
-- (NSObject<HPLoaderOptionComponents> *)checkboxComponentWithLabel:(NSString *)label;
-- (NSObject<HPLoaderOptionComponents> *)cpuComponentWithLabel:(NSString *)label;
-- (NSObject<HPLoaderOptionComponents> *)addressComponentWithLabel:(NSString *)label andValue:(Address)value;
-- (NSObject<HPLoaderOptionComponents> *)checkboxComponentWithLabel:(NSString *)label checked:(BOOL)checked;
-- (NSObject<HPLoaderOptionComponents> *)stringListComponentWithLabel:(NSString *)label andList:(NSArray<NSString *> *)strings;
-- (NSObject<HPLoaderOptionComponents> *)comboBoxComponentWithLabel:(NSString *)label andList:(NSArray<NSString *> *)strings;
+- (nonnull NSObject<HPLoaderOptionComponents> *)addressComponentWithLabel:(nonnull NSString *)label;
+- (nonnull NSObject<HPLoaderOptionComponents> *)checkboxComponentWithLabel:(nonnull NSString *)label;
+- (nonnull NSObject<HPLoaderOptionComponents> *)cpuComponentWithLabel:(nonnull NSString *)label;
+- (nonnull NSObject<HPLoaderOptionComponents> *)addressComponentWithLabel:(nonnull NSString *)label andValue:(Address)value;
+- (nonnull NSObject<HPLoaderOptionComponents> *)checkboxComponentWithLabel:(nonnull NSString *)label checked:(BOOL)checked;
+- (nonnull NSObject<HPLoaderOptionComponents> *)stringListComponentWithLabel:(nonnull NSString *)label andList:(nonnull NSArray<NSString *> *)strings;
+- (nonnull NSObject<HPLoaderOptionComponents> *)comboBoxComponentWithLabel:(nonnull NSString *)label andList:(nonnull NSArray<NSString *> *)strings;
 
 // Call Destination
-- (NSObject<HPCallDestination> *)callDestination:(Address)address;
-- (NSObject<HPCallDestination> *)callDestination:(Address)address withCPUMode:(uint8_t)cpuMode;
+- (nullable NSObject<HPCallDestination> *)callDestination:(Address)address;
+- (nullable NSObject<HPCallDestination> *)callDestination:(Address)address withCPUMode:(uint8_t)cpuMode;
 
 @end

--- a/include/Hopper/HPHopperUUID.h
+++ b/include/Hopper/HPHopperUUID.h
@@ -10,15 +10,11 @@
 // PARTICULAR PURPOSE.
 //
 
-#import "CommonTypes.h"
+#import <Foundation/Foundation.h>
 
-@protocol HPTypeEnumField
+@protocol HPHopperUUID
 
-- (nullable NSString *)name;
-- (void)setName:(nullable NSString *)name;
-
-- (int64_t)value;
-- (void)setValue:(int64_t)value;
+- (nonnull NSString *)UUIDString;
 
 @end
 

--- a/include/Hopper/HPLoaderOptionComponents.h
+++ b/include/Hopper/HPLoaderOptionComponents.h
@@ -21,11 +21,11 @@
 
 @property (assign) BOOL isChecked;
 
-@property (strong) HopperUUID *cpuUUID;
-@property (strong) NSString *cpuFamily;
-@property (strong) NSString *cpuSubFamily;
+@property (nullable, strong) HopperUUID *cpuUUID;
+@property (nullable, strong) NSString *cpuFamily;
+@property (nullable, strong) NSString *cpuSubFamily;
 
-@property (strong) NSArray *stringList;
+@property (nullable, strong) NSArray *stringList;
 @property (assign) NSUInteger selectedStringIndex;
 
 @end

--- a/include/Hopper/HPMethodArgument.h
+++ b/include/Hopper/HPMethodArgument.h
@@ -17,12 +17,12 @@
 
 @protocol HPMethodArgument
 
-- (NSObject<HPMethodSignature> *)owner;
+- (nonnull NSObject<HPMethodSignature> *)owner;
 
-- (NSString *)name;
-- (void)setName:(NSString *)name;
+- (nullable NSString *)name;
+- (void)setName:(nullable NSString *)name;
 
-- (NSObject<HPTypeDesc> *)type;
-- (void)setType:(NSObject<HPTypeDesc> *)type;
+- (nonnull NSObject<HPTypeDesc> *)type;
+- (void)setType:(nonnull NSObject<HPTypeDesc> *)type;
 
 @end

--- a/include/Hopper/HPMethodSignature.h
+++ b/include/Hopper/HPMethodSignature.h
@@ -17,25 +17,25 @@
 
 @protocol HPMethodSignature
 
-- (NSObject<HPTypeDesc> *)returnType;
-- (void)setReturnType:(NSObject<HPTypeDesc> *)returnType;
+- (nullable NSObject<HPTypeDesc> *)returnType;
+- (void)setReturnType:(nullable NSObject<HPTypeDesc> *)returnType;
 
-- (NSString *)argumentNameAtIndex:(NSUInteger)index;
-- (NSString *)argumentNameAtIndex:(NSUInteger)index withDefaultBasename:(NSString *)defaultBasename;
+- (nullable NSString *)argumentNameAtIndex:(NSUInteger)index;
+- (nullable NSString *)argumentNameAtIndex:(NSUInteger)index withDefaultBasename:(nullable NSString *)defaultBasename;
 
 - (NSUInteger)argumentCount;
-- (NSObject<HPMethodArgument> *)argumentAtIndex:(NSUInteger)index;
-- (void)addArgument:(NSObject<HPMethodArgument> *)argument;
+- (nullable NSObject<HPMethodArgument> *)argumentAtIndex:(NSUInteger)index;
+- (void)addArgument:(nonnull NSObject<HPMethodArgument> *)argument;
 - (void)removeArgumentAtIndex:(NSUInteger)index;
-- (NSArray<NSObject<HPMethodArgument> *> *)allArguments;
+- (nonnull NSArray<NSObject<HPMethodArgument> *> *)allArguments;
 
-- (void)addArgumentWithType:(NSObject<HPTypeDesc> *)type;
-- (void)addArgumentWithType:(NSObject<HPTypeDesc> *)type name:(NSString *)name;
-- (void)insertArgumentWithType:(NSObject<HPTypeDesc> *)type atIndex:(NSUInteger)index;
-- (void)insertArgumentWithType:(NSObject<HPTypeDesc> *)type andName:(NSString *)name atIndex:(NSUInteger)index;
+- (void)addArgumentWithType:(nonnull NSObject<HPTypeDesc> *)type;
+- (void)addArgumentWithType:(nonnull NSObject<HPTypeDesc> *)type name:(nullable NSString *)name;
+- (void)insertArgumentWithType:(nonnull NSObject<HPTypeDesc> *)type atIndex:(NSUInteger)index;
+- (void)insertArgumentWithType:(nonnull NSObject<HPTypeDesc> *)type andName:(nullable NSString *)name atIndex:(NSUInteger)index;
 
-- (NSString *)string;
-- (NSString *)stringWithMethodName:(NSString *)name;
-- (NSString *)stringWithMethodName:(NSString *)name andDefaultArgumentBasename:(NSString *)argBasename;
+- (nonnull NSString *)string;
+- (nonnull NSString *)stringWithMethodName:(nullable NSString *)name;
+- (nonnull NSString *)stringWithMethodName:(nullable NSString *)name andDefaultArgumentBasename:(nullable NSString *)argBasename;
 
 @end

--- a/include/Hopper/HPProcedure.h
+++ b/include/Hopper/HPProcedure.h
@@ -28,55 +28,55 @@
 - (int32_t)localsSize;
 
 - (NSUInteger)basicBlockCount;
-- (NSObject<HPBasicBlock> *)firstBasicBlock;
-- (NSObject<HPBasicBlock> *)basicBlockStartingAt:(Address)address;
-- (NSObject<HPBasicBlock> *)basicBlockContainingInstructionAt:(Address)address;
-- (NSObject<HPBasicBlock> *)basicBlockAtIndex:(NSUInteger)index;
+- (nullable NSObject<HPBasicBlock> *)firstBasicBlock;
+- (nullable NSObject<HPBasicBlock> *)basicBlockStartingAt:(Address)address;
+- (nullable NSObject<HPBasicBlock> *)basicBlockContainingInstructionAt:(Address)address;
+- (nullable NSObject<HPBasicBlock> *)basicBlockAtIndex:(NSUInteger)index;
 
-- (NSObject<HPSegment> *)segment;
+- (nonnull NSObject<HPSegment> *)segment;
 
 - (Address)entryPoint;
-- (NSArray<NSObject<HPBasicBlock> *> *)allExitBlocks;
+- (nullable NSArray<NSObject<HPBasicBlock> *> *)allExitBlocks;
 
 // Stack
 - (int32_t)stackPointerOffsetAt:(Address)address;
 
 // Local Labels
 - (BOOL)hasLocalLabelAtAddress:(Address)address;
-- (NSString *)localLabelAtAddress:(Address)address;
-- (void)setLocalLabel:(NSString *)name atAddress:(Address)address;
-- (NSString *)declareLocalLabelAt:(Address)address;
+- (nullable NSString *)localLabelAtAddress:(Address)address;
+- (void)setLocalLabel:(nullable NSString *)name atAddress:(Address)address;
+- (nonnull NSString *)declareLocalLabelAt:(Address)address;
 - (void)removeLocalLabelAtAddress:(Address)address;
-- (Address)addressOfLocalLabel:(NSString *)name;
+- (Address)addressOfLocalLabel:(nonnull NSString *)name;
 
 // Rename register
-- (void)renameRegisterOfClass:(RegClass)regCls andIndex:(NSUInteger)regIndex to:(NSString *)name;
-- (NSString *)nameOverrideForRegisterOfClass:(RegClass)regCls andIndex:(NSUInteger)regIndex;
+- (void)renameRegisterOfClass:(RegClass)regCls andIndex:(NSUInteger)regIndex to:(nullable NSString *)name;
+- (nullable NSString *)nameOverrideForRegisterOfClass:(RegClass)regCls andIndex:(NSUInteger)regIndex;
 - (void)clearNameOverrideForRegisterOfClass:(RegClass)regCls andIndex:(NSUInteger)regIndex;
 
 // Call Graph
-- (NSArray<NSObject<HPCallReference> *> *)allCallers;
-- (NSArray<NSObject<HPCallReference> *> *)allCallees;
+- (nullable NSArray<NSObject<HPCallReference> *> *)allCallers;
+- (nullable NSArray<NSObject<HPCallReference> *> *)allCallees;
 
-- (NSArray<NSObject<HPProcedure> *> *)allCalleeProcedures;
-- (NSArray<NSObject<HPProcedure> *> *)allCallerProcedures;
+- (nullable NSArray<NSObject<HPProcedure> *> *)allCalleeProcedures;
+- (nullable NSArray<NSObject<HPProcedure> *> *)allCallerProcedures;
 
 // Variables
-- (NSString *)variableNameForDisplacement:(int64_t)disp;
-- (BOOL)setVariableName:(NSString *)name forDisplacement:(int64_t)disp;
-- (NSString *)resolvedVariableNameForDisplacement:(int64_t)disp usingCPUContext:(NSObject<CPUContext> *)cpuContext;
+- (nullable NSString *)variableNameForDisplacement:(int64_t)disp;
+- (BOOL)setVariableName:(nullable NSString *)name forDisplacement:(int64_t)disp;
+- (nullable NSString *)resolvedVariableNameForDisplacement:(int64_t)disp usingCPUContext:(nonnull NSObject<CPUContext> *)cpuContext;
 
 // Signature
-- (NSObject<HPMethodSignature> *)signature;
-- (void)setSignature:(NSObject<HPMethodSignature> *)signature reason:(SignatureCreationReason)reason;
-- (void)setSignature:(NSObject<HPMethodSignature> *)signature propagatingSignature:(BOOL)propagateSignature reason:(SignatureCreationReason)reason;
+- (nullable NSObject<HPMethodSignature> *)signature;
+- (void)setSignature:(nullable NSObject<HPMethodSignature> *)signature reason:(SignatureCreationReason)reason;
+- (void)setSignature:(nullable NSObject<HPMethodSignature> *)signature propagatingSignature:(BOOL)propagateSignature reason:(SignatureCreationReason)reason;
 - (CallingConvention)callingConvention;
 - (CallingConvention)resolvedCallingConvention;
 - (void)setCallingConvention:(CallingConvention)cc;
 
 // Tags
-- (void)addTag:(NSObject<HPTag> *)tag;
-- (void)removeTag:(NSObject<HPTag> *)tag;
-- (BOOL)hasTag:(NSObject<HPTag> *)tag;
+- (void)addTag:(nonnull NSObject<HPTag> *)tag;
+- (void)removeTag:(nonnull NSObject<HPTag> *)tag;
+- (BOOL)hasTag:(nonnull NSObject<HPTag> *)tag;
 
 @end

--- a/include/Hopper/HPSection.h
+++ b/include/Hopper/HPSection.h
@@ -16,7 +16,7 @@
 
 @protocol HPSection
 
-@property (nonatomic, copy) NSString *sectionName;
+@property (nonatomic, nullable, copy) NSString *sectionName;
 
 @property (nonatomic, assign) uint64_t fileOffset;
 @property (nonatomic, assign) uint64_t fileLength;
@@ -38,9 +38,9 @@
 
 - (BOOL)hasDataOnDisk;
 
-- (NSObject<HPSegment> *)segment;
-- (NSObject<HPSection> *)previousSection;
-- (NSObject<HPSection> *)nextSection;
+- (nonnull NSObject<HPSegment> *)segment;
+- (nullable NSObject<HPSection> *)previousSection;
+- (nullable NSObject<HPSection> *)nextSection;
 
 - (BOOL)sectionContainsAddress:(Address)address;
 

--- a/include/Hopper/HPSegment.h
+++ b/include/Hopper/HPSegment.h
@@ -17,7 +17,7 @@
 
 @protocol HPSegment
 
-@property (nonatomic, copy) NSString *segmentName;
+@property (nonatomic, nullable, copy) NSString *segmentName;
 
 @property (nonatomic, assign) uint64_t fileOffset;
 @property (nonatomic, assign) uint64_t fileLength;
@@ -28,8 +28,8 @@
 - (NSUInteger)segmentIndex;
 
 - (BOOL)hasMappedData;
-- (NSData *)mappedData;
-- (void)setMappedData:(NSData *)data;
+- (nullable NSData *)mappedData;
+- (void)setMappedData:(nullable NSData *)data;
 
 - (Address)startAddress;
 - (Address)endAddress;
@@ -38,29 +38,29 @@
 
 - (BOOL)containsVirtualAddress:(Address)virtualAddress;
 
-- (NSArray<NSObject<HPSection> *> *)sections;
+- (nonnull NSArray<NSObject<HPSection> *> *)sections;
 - (NSUInteger)sectionCount;
 
-- (NSObject<HPSegment> *)nextSegment;
-- (NSObject<HPSegment> *)previousSegment;
+- (nullable NSObject<HPSegment> *)nextSegment;
+- (nullable NSObject<HPSegment> *)previousSegment;
 
-- (NSObject<HPSection> *)addSectionAt:(Address)address size:(size_t)length;
-- (NSObject<HPSection> *)addSectionAt:(Address)address toExcludedAddress:(Address)endAddress;
+- (nonnull NSObject<HPSection> *)addSectionAt:(Address)address size:(size_t)length;
+- (nonnull NSObject<HPSection> *)addSectionAt:(Address)address toExcludedAddress:(Address)endAddress;
 
-- (NSObject<HPSection> *)firstSection;
-- (NSObject<HPSection> *)lastSection;
-- (NSObject<HPSection> *)sectionNamed:(NSString *)name;
+- (nullable NSObject<HPSection> *)firstSection;
+- (nullable NSObject<HPSection> *)lastSection;
+- (nullable NSObject<HPSection> *)sectionNamed:(nonnull NSString *)name;
 
 - (NSUInteger)procedureCount;
 - (BOOL)hasProcedureAt:(Address)virtualAddress;
-- (NSObject<HPProcedure> *)procedureAt:(Address)virtualAddress;
-- (NSObject<HPProcedure> *)procedureAtIndex:(NSUInteger)index;
-- (NSInteger)procedureIndex:(NSObject<HPProcedure> *)procedure;
-- (NSArray<NSObject<HPProcedure> *> *)procedures;
+- (nullable NSObject<HPProcedure> *)procedureAt:(Address)virtualAddress;
+- (nullable NSObject<HPProcedure> *)procedureAtIndex:(NSUInteger)index;
+- (NSInteger)procedureIndex:(nonnull NSObject<HPProcedure> *)procedure;
+- (nonnull NSArray<NSObject<HPProcedure> *> *)procedures;
 
 // XREFs
-- (NSArray<NSNumber *> *)referencesToAddress:(Address)virtualAddress;
-- (NSArray<NSNumber *> *)referencesFromAddress:(Address)virtualAddress;
+- (nullable NSArray<NSNumber *> *)referencesToAddress:(Address)virtualAddress;
+- (nullable NSArray<NSNumber *> *)referencesFromAddress:(Address)virtualAddress;
 - (void)removeReferencesOfAddress:(Address)referenced fromAddress:(Address)origin;
 - (void)addReferencesToAddress:(Address)referenced fromAddress:(Address)origin;
 

--- a/include/Hopper/HPTag.h
+++ b/include/Hopper/HPTag.h
@@ -14,6 +14,6 @@
 
 @protocol HPTag <NSObject>
 
-- (NSString *)name;
+- (nonnull NSString *)name;
 
 @end

--- a/include/Hopper/HPTypeDesc.h
+++ b/include/Hopper/HPTypeDesc.h
@@ -29,8 +29,8 @@
 - (BOOL)isStructured;
 - (BOOL)isEnum;
 
-- (NSString *)name;
-- (void)setName:(NSString *)name;
+- (nullable NSString *)name;
+- (void)setName:(nullable NSString *)name;
 
 - (BOOL)forwardDeclaration;
 - (void)setForwardDeclaration:(BOOL)forward;
@@ -40,31 +40,31 @@
 - (void)setSingleLineDisplay:(BOOL)singleLine;
 
 // String representation
-- (NSString *)string;
-- (NSString *)shortString;
+- (nonnull NSString *)string;
+- (nonnull NSString *)shortString;
 
 // Arrays
 - (NSUInteger)arrayItemCount;
 
 // Struct fields
-- (BOOL)addStructureField:(NSObject<HPTypeStructField> *)field;
-- (NSObject<HPTypeStructField> *)addStructureFieldOfType:(NSObject<HPTypeDesc> *)type named:(NSString *)name;
-- (NSObject<HPTypeStructField> *)addStructureFieldOfType:(NSObject<HPTypeDesc> *)type named:(NSString *)name withComment:(NSString *)comment;
-- (BOOL)removeStructureField:(NSObject<HPTypeStructField> *)field;
+- (BOOL)addStructureField:(nonnull NSObject<HPTypeStructField> *)field;
+- (nonnull NSObject<HPTypeStructField> *)addStructureFieldOfType:(nonnull NSObject<HPTypeDesc> *)type named:(nullable NSString *)name;
+- (nonnull NSObject<HPTypeStructField> *)addStructureFieldOfType:(nonnull NSObject<HPTypeDesc> *)type named:(nullable NSString *)name withComment:(nullable NSString *)comment;
+- (BOOL)removeStructureField:(nonnull NSObject<HPTypeStructField> *)field;
 - (BOOL)removeAllStructureFields;
 
 // Enum
-- (NSObject<HPTypeEnumField> *)addEnumField;
-- (NSObject<HPTypeEnumField> *)addEnumFieldWithName:(NSString *)name;
-- (NSObject<HPTypeEnumField> *)addEnumFieldWithName:(NSString *)name andValue:(int64_t)value;
-- (NSObject<HPTypeEnumField> *)insertEnumFieldWithName:(NSString *)name andValue:(int64_t)value atIndex:(NSUInteger)index;
-- (BOOL)removeEnumField:(NSObject<HPTypeEnumField> *)field;
+- (nonnull NSObject<HPTypeEnumField> *)addEnumField;
+- (nonnull NSObject<HPTypeEnumField> *)addEnumFieldWithName:(nonnull NSString *)name;
+- (nonnull NSObject<HPTypeEnumField> *)addEnumFieldWithName:(nullable NSString *)name andValue:(int64_t)value;
+- (nonnull NSObject<HPTypeEnumField> *)insertEnumFieldWithName:(nullable NSString *)name andValue:(int64_t)value atIndex:(NSUInteger)index;
+- (BOOL)removeEnumField:(nonnull NSObject<HPTypeEnumField> *)field;
 - (BOOL)removeAllEnumFields;
 - (int)enumSize;
 - (void)setEnumSize:(int)sizeInBytes;
 
 // Function pointers
-- (NSObject<HPMethodSignature> *)signature;
-- (void)setSignature:(NSObject<HPMethodSignature> *)signature;
+- (nullable NSObject<HPMethodSignature> *)signature;
+- (void)setSignature:(nullable NSObject<HPMethodSignature> *)signature;
 
 @end

--- a/include/Hopper/HPTypeStructField.h
+++ b/include/Hopper/HPTypeStructField.h
@@ -14,18 +14,18 @@
 
 @protocol HPTypeStructField
 
-- (NSString *)name;
-- (void)setName:(NSString *)name;
+- (nullable NSString *)name;
+- (void)setName:(nullable NSString *)name;
 
-- (NSString *)comment;
-- (void)setComment:(NSString *)comment;
+- (nullable NSString *)comment;
+- (void)setComment:(nullable NSString *)comment;
 
 - (ArgFormat)displayFormat;
 - (void)setDisplayFormat:(ArgFormat)displayFormat;
 
 - (NSUInteger)fieldIndex;
-- (NSString *)string;
-- (NSString *)shortString;
+- (nonnull NSString *)string;
+- (nonnull NSString *)shortString;
 
 @end
 

--- a/include/Hopper/HopperPlugin.h
+++ b/include/Hopper/HopperPlugin.h
@@ -13,31 +13,31 @@
 #import <Foundation/Foundation.h>
 #import "CommonTypes.h"
 
-#define HOPPER_CURRENT_SDK_VERSION  1
+#define HOPPER_CURRENT_SDK_VERSION  4
 
-@class HopperUUID;
+@protocol HPHopperUUID;
 @protocol HPHopperServices;
 
 @protocol HopperPlugin <NSObject>
 
-- (instancetype)initWithHopperServices:(NSObject<HPHopperServices> *)services;
+- (nonnull instancetype)initWithHopperServices:(nonnull NSObject<HPHopperServices> *)services;
 
 /// Should return the HOPPER_CURRENT_SDK_VERSION constant.
 /// This is used by Hopper to know the SDK version which was used when the plugin was compiled.
 + (int)sdkVersion;
 
-- (HopperUUID *)pluginUUID;
+- (nonnull NSObject<HPHopperUUID> *)pluginUUID;
 - (HopperPluginType)pluginType;
 
-- (NSString *)pluginName;
-- (NSString *)pluginDescription;
-- (NSString *)pluginAuthor;
-- (NSString *)pluginCopyright;
-- (NSString *)pluginVersion;
+- (nonnull NSString *)pluginName;
+- (nonnull NSString *)pluginDescription;
+- (nonnull NSString *)pluginAuthor;
+- (nonnull NSString *)pluginCopyright;
+- (nonnull NSString *)pluginVersion;
 
 /// Returns a string identifying the plugin for the command line tool.
 /// For instance, the Mach-O loader returns "Mach-O".
 /// You should avoid spaces in order to avoid quotes in the command line.
-- (NSString *)commandLineIdentifier;
+- (nonnull NSArray<NSString *> *)commandLineIdentifiers;
 
 @end

--- a/include/Hopper/HopperTool.h
+++ b/include/Hopper/HopperTool.h
@@ -23,6 +23,6 @@
 /// A description contains at least a HPM_TITLE key, and a HPM_SELECTOR or a HPM_SUBMENU key.
 /// The HPM_SELECTOR is a string which contains a selector name, which will be resolved by
 /// Hopper at runtime, using the NSSelectorFromString system method.
-- (NSArray *)toolMenuDescription;
+- (nonnull NSArray<NSDictionary<NSString *, id> *> *)toolMenuDescription;
 
 @end

--- a/loaders/GBALoader/GBALoader/GBALoader.m
+++ b/loaders/GBALoader/GBALoader/GBALoader.m
@@ -85,7 +85,7 @@
     return @[];
 }
 
-- (FileLoaderLoadingStatus)loadData:(NSData *)data
+- (FileLoaderLoadingStatus)loadData:(const void *)data
                              length:(size_t)length
                        originalPath:(NSString *)fileFullPath
               usingDetectedFileType:(NSObject<HPDetectedFileType> *)fileType
@@ -116,7 +116,7 @@
     callback(@"Loading cartridge ROM", 0.6);
     NSObject<HPSegment> *segment = [file segmentNamed:@"ROM0"];
     NSObject<HPSection> *section = [file sectionNamed:@"ROM0"];
-    segment.mappedData = data;
+    segment.mappedData = [NSData dataWithBytes:data length:length];
     segment.fileOffset = 0;
     segment.fileLength = length;
     

--- a/loaders/GBALoader/GBALoader/GBALoader.m
+++ b/loaders/GBALoader/GBALoader/GBALoader.m
@@ -37,7 +37,7 @@
     return @"0.0.1";
 }
 
-- (NSString *)commandLineIdentifier {
+- (NSString *)commandLineIdentifiers {
     return @"GBA";
 }
 
@@ -57,13 +57,15 @@
     return NO;
 }
 
-- (NSArray<NSObject<HPDetectedFileType> *> *)detectedTypesForData:(NSData *)data
-                                                      ofFileNamed:(NSString *)filename {
-    if ([data length] < 4) {
+- (NSArray<NSObject<HPDetectedFileType> *> *)detectedTypesForData:(const void *)data
+                                                           length:(size_t) length
+                                                      ofFileNamed:(NSString *)filename
+                                                           atPath:(nullable NSString *) fileFullPath{
+    if (length < 4) {
         return @[];
     }
 
-    const void *bytes = (const void *)[data bytes];
+    const void *bytes = (const void *)data;
     
     if (OSReadBigInt32(bytes, 0) == GBA_MAGIC_NUM) {
         NSObject<HPDetectedFileType> *type = [self.services detectedType];
@@ -84,6 +86,8 @@
 }
 
 - (FileLoaderLoadingStatus)loadData:(NSData *)data
+                             length:(size_t)length
+                       originalPath:(NSString *)fileFullPath
               usingDetectedFileType:(NSObject<HPDetectedFileType> *)fileType
                             options:(FileLoaderOptions)options
                             forFile:(NSObject<HPDisassembledFile> *)file
@@ -114,10 +118,10 @@
     NSObject<HPSection> *section = [file sectionNamed:@"ROM0"];
     segment.mappedData = data;
     segment.fileOffset = 0;
-    segment.fileLength = [data length];
+    segment.fileLength = length;
     
     section.fileOffset = 0;
-    section.fileLength = [data length];
+    section.fileLength = length;
     
     NSObject<HPTypeDesc> *type = [file structureType];
     type.name = @"gba_rom_header";
@@ -175,20 +179,34 @@
     return DIS_OK;
 }
 
-- (NSData *)extractFromData:(NSData *)data
+- (NSData *)extractFromData:(const void *)data
+                     length:(size_t)length
       usingDetectedFileType:(NSObject<HPDetectedFileType> *)fileType
+           originalFileName:(NSString *)filename
+               originalPath:(NSString *)fileFullPath
          returnAdjustOffset:(uint64_t *)adjustOffset
        returnAdjustFilename:(NSString *__autoreleasing *)newFilename {
     return nil;
 }
 
+- (void)setupFile:(nonnull NSObject<HPDisassembledFile> *)file
+afterExtractionOf:(nonnull NSString *)filename
+     originalPath:(nullable NSString *)fileFullPath
+             type:(nonnull NSObject<HPDetectedFileType> *)fileType {
+    return;
+}
+
 - (void)fixupRebasedFile:(NSObject<HPDisassembledFile> *)file
                withSlide:(int64_t)slide
-        originalFileData:(NSData *)fileData {
+        originalFileData:(const void *)fileData
+                  length:(size_t)length
+            originalPath:(NSString *)fileFullPath {
     // Not Supported
 }
 
-- (FileLoaderLoadingStatus)loadDebugData:(NSData *)data
+- (FileLoaderLoadingStatus)loadDebugData:(const void *)data
+                                  length:(size_t)length
+                            originalPath:(NSString *)fileFullPath
                                  forFile:(NSObject<HPDisassembledFile> *)file
                            usingCallback:(FileLoadingCallbackInfo)callback {
     return DIS_NotSupported;


### PR DESCRIPTION
Updates plugin so it's compatible with recent versions of Hopper SDK. Mostly deals with a number of `FileLoader.h` changes from 4.5 onwards.